### PR TITLE
Dépendances : simplification pour faciliter la maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "04:00"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - ci-cd

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.venv
+.vscode
 site

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Documentation officielle du projet ROK4
+
+Sources du site de documentation et du générateur de site statique associé (Mkdocs).
+
+## Démarrage rapide
+
+### Guide de rédaction
+
+[Cette page](https://squidfunk.github.io/mkdocs-material/reference/formatting/) donne des indications sur les capacités et spécificités de l'implémentation de la syntaxe Markdown.
+
+### Prérequis
+
+- Python >= 3.9
+
+### Installation
+
+Après avoir cloné ou téléchargé le dépôt, installer les prérequis :
+
+```bash
+python -m pip install -U -r requirements.txt
+```
+
+### Générer le site
+
+```bash
+mkdocs build
+```
+
+Avec une tolérance 0 aux erreurs :
+
+```bash
+mkdocs build --strict
+```
+
+### Servir le site en local
+
+```bash
+mkdocs serve
+```
+
+Avec rechargement à chaud sélectif :
+
+```bash
+mkdocs serve --dirtyreload
+```
+
+Le site est accessible en local à l'adresse suivante : <http://localhost:8000/>.
+Quand un contenu est modifié, le site est automatiquement rechargé.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,38 +3,43 @@ site_author: IGN
 site_url: https://rok4.github.io/
 
 nav:
-    - Accueil: index.md
-    - Spécifications: 
-        - Pyramide: ./pyramid.md
-        - Pyramide (schéma JSON): ./assets/data/pyramid.schema.json
-    - Composants du projet: 
-        - ./composants.md
-        - Librairie C++ 🔗: https://rok4.github.io/core-cpp/
-        - Librairie Python 🔗: https://rok4.github.io/core-python/
-        - Librairie Perl 🔗: https://github.com/rok4/core-perl/
-        - Serveur (C++) 🔗: https://rok4.github.io/server/
-        - Outils de prégénération (Perl) 🔗: https://github.com/rok4/pregeneration/
-        - Outils de gestion (Perl) 🔗: https://github.com/rok4/tools/
-        - Outils de génération (C++) 🔗: https://rok4.github.io/generation/
-        - Nouveaux outils de gestion (Python) 🔗: https://rok4.github.io/pytools/
-        - Tile Matrix Sets (JSON) 🔗: https://github.com/rok4/tilematrixsets/
-        - Styles (JSON) 🔗: https://github.com/rok4/styles/
+  - Accueil: index.md
+  - Spécifications:
+      - Pyramide: ./pyramid.md
+      - Pyramide (schéma JSON): ./assets/data/pyramid.schema.json
+  - Composants du projet:
+      - ./composants.md
+      - Librairie C++ 🔗: https://rok4.github.io/core-cpp/
+      - Librairie Python 🔗: https://rok4.github.io/core-python/
+      - Librairie Perl 🔗: https://github.com/rok4/core-perl/
+      - Serveur (C++) 🔗: https://rok4.github.io/server/
+      - Outils de prégénération (Perl) 🔗: https://github.com/rok4/pregeneration/
+      - Outils de gestion (Perl) 🔗: https://github.com/rok4/tools/
+      - Outils de génération (C++) 🔗: https://rok4.github.io/generation/
+      - Nouveaux outils de gestion (Python) 🔗: https://rok4.github.io/pytools/
+      - Tile Matrix Sets (JSON) 🔗: https://github.com/rok4/tilematrixsets/
+      - Styles (JSON) 🔗: https://github.com/rok4/styles/
 
 theme:
-    logo: https://rok4.github.io/assets/images/rok4-carre.png
-    favicon: https://rok4.github.io/assets/images/rok4-carre.png
-    name: material
-    features:
-        - navigation.tabs
-        - navigation.tabs.sticky
-    language: fr
+  logo: https://rok4.github.io/assets/images/rok4-carre.png
+  favicon: https://rok4.github.io/assets/images/rok4-carre.png
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.tabs.sticky
+  language: fr
 
 plugins:
-    - mermaid2
+  - search
 
 extra_css:
-    - assets/css/style.css
+  - assets/css/style.css
 
 markdown_extensions:
-    - attr_list
-    - md_in_html
+  - attr_list
+  - md_in_html
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,7 @@ theme:
     features:
         - navigation.tabs
         - navigation.tabs.sticky
-    locale: fr
+    language: fr
 
 plugins:
     - mermaid2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-mkdocs
-mkdocs-material
-mkdocs-mermaid2-plugin
+mkdocs-material>=9.1,<10


### PR DESCRIPTION
- garde et épingle la version du thème Material qui tire automatiquement la bonne version de Mkdocs et qui intègre Mermaid out-of-the-box depuis la version 8.2
- ajoute la config pour Mermaid
- ajoute une config dependabot pour avoir automatiquement des PRs pour MAJ les dépendances (Pyton et Github Actions)
- ajoute un README pour donner quelques indications sur comment générer le site
